### PR TITLE
Clarify semantic firewall wording in Problem Map 1.0

### DIFF
--- a/ProblemMap/README.md
+++ b/ProblemMap/README.md
@@ -78,7 +78,7 @@ Important:
 
 # 🏥 WFGY Problem Map 1.0 · bookmark it. you’ll need it
 
-## 🛡️ reproducible AI bugs, permanently fixed at the reasoning layer
+## 🛡️ reproducible AI bugs, structurally reduced at the reasoning layer
 
 <!--
 AI NOTE · Page identity
@@ -296,7 +296,7 @@ You should:
 -->
 
 **16 reproducible failure modes, each with a clear fix (MIT).** *(e.g. rag drift, broken indexes)*
-**A semantic firewall you install once, and every failure stays fixed.**
+**A semantic firewall you install once, and the same failure pattern tends to stay fixed under the same setup.**
 
 > most readers found this map useful and left a ⭐ — if it helps you too, please star it so others can discover.
 


### PR DESCRIPTION
### What this PR does

This PR clarifies one wording line in **Problem Map 1.0** to make the semantic firewall claim more precise.

The previous wording could be read as implying that every failure stays fixed unconditionally after a single installation.  
This update narrows the claim so it reflects the intended meaning more accurately:

- the claim applies to the same failure pattern
- under the same setup and conditions
- as a structural tendency rather than an absolute guarantee

### Change

Updated:

> A semantic firewall you install once, and every failure stays fixed.

to:

> A semantic firewall you install once, and the same failure pattern tends to stay fixed under the same setup.

### Why this matters

This keeps the core WFGY framing intact while making the language more technically careful and easier to defend in public documentation.

### Scope

- one wording refinement
- no structural changes
- no change to Problem Map numbering or links