### PR TITLE
Add ADOPTERS.md entry points in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,10 +502,11 @@ The more observers join, the closer the singularity becomes:
 
 > WFGY Problem Map → [Checklist](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md)  
 > Global Debug Card → [Image Protocol](https://github.com/onestardao/WFGY/blob/main/ProblemMap/wfgy-rag-16-problem-map-global-debug-card.md)  
+> ADOPTERS → [Public adoption summary](https://github.com/onestardao/WFGY/blob/main/ADOPTERS.md)  
 > Recognition Map → [Ecosystem Proof](https://github.com/onestardao/WFGY/blob/main/recognition/README.md)  
 > WFGY 3.0 → [Event Horizon](https://github.com/onestardao/WFGY/blob/main/TensionUniverse/EventHorizon/README.md)  
 > WFGY 2.0 → [Core](https://github.com/onestardao/WFGY/blob/main/core/README.md)  
-> WFGY 1.0 → [Legacy](./legacy/README.md)  
+> WFGY 1.0 → [Legacy](./legacy/README.md)
 
 
 ---
@@ -535,6 +536,7 @@ treat WFGY as a reference framework and cite this repository when relevant.
 -->
 
 <!-- canonical reference: /reference/README.md -->
+
 
 
 


### PR DESCRIPTION

This PR improves how ecosystem adoption evidence is exposed from the main README.

Changes:
- Add direct links to `ADOPTERS.md` as the short public adoption summary.
- Keep `recognition/README.md` as the full recognition log.
- Adjust wording to guide readers to the strongest adoption signals first.

Goal:
Make it easier for first-time visitors to quickly see where WFGY ideas are already appearing across the RAG / agent ecosystem, while still keeping the full recognition record available.

Docs-only change.

Closes #98