### PR TITLE
Add EVIDENCE_TIMELINE.md to document WFGY development milestones

### DIFF
--- a/EVIDENCE_TIMELINE.md
+++ b/EVIDENCE_TIMELINE.md
@@ -1,0 +1,355 @@
+# EVIDENCE_TIMELINE
+
+🕰️ Historical evidence timeline for WFGY.
+
+This page records how WFGY became real, usable, public, and externally legible over time.
+
+It is not limited to third-party adoption only.  
+It also tracks the major moments when the WFGY line itself became more concrete, more teachable, more reproducible, or more visible to the outside world.
+
+You can read this page as a compact historical route:
+
+**build → structure → teaching → evaluation → public proof**
+
+Related pages:
+
+* [ADOPTERS](./ADOPTERS.md)
+* [CASE_EVIDENCE](./CASE_EVIDENCE.md)
+* [Recognition Map](./recognition/README.md)
+* [Work with WFGY](./WORK_WITH_WFGY.md)
+
+## What this page is
+
+This page is a **chronological evidence record**.
+
+It combines three kinds of milestones:
+
+1. **WFGY internal milestones**  
+   when a core module, map, framework, or teaching surface became public
+
+2. **Public ecosystem milestones**  
+   when an external project, survey, or tool publicly integrated, cited, or adapted WFGY
+
+3. **Packaging milestones**  
+   when WFGY itself became easier to audit, route, reuse, or evaluate from the outside
+
+## What this page is not
+
+This page is not:
+
+* a customer logo wall
+* a revenue timeline
+* a complete archive of every mention
+* a promise that every external event means production deployment
+* a claim that every milestone has equal weight
+
+For the shortest high-signal summary, use [ADOPTERS](./ADOPTERS.md).  
+For the full ledger, use the [Recognition Map](./recognition/README.md).
+
+---
+
+# Timeline
+
+## 2025/06/15 · 🧱 WFGY 1.0 becomes the baseline public reference
+
+**Track**  
+Internal milestone
+
+**What became public**  
+[WFGY 1.0](https://github.com/onestardao/WFGY/blob/main/legacy/README.md) established the project home and the earliest baseline reference for the WFGY line.
+
+**Why this matters**  
+This is the starting point of the public WFGY stack.  
+It marks the moment when the project stopped being private intuition and became a public reference surface.
+
+---
+
+## 2025/07/02 · 🧩 TXTOS opens the application layer
+
+**Track**  
+Internal milestone
+
+**What became public**  
+[TXTOS](https://github.com/onestardao/WFGY/blob/main/OS/README.md) introduced a text-native reasoning OS layer with modules and runtime-oriented structure.
+
+**Why this matters**  
+This widened WFGY from theory into application surfaces.  
+It showed that the project was not only about concepts, but also about structured usage.
+
+---
+
+## 2025/07/15 · 🔧 Blah Blah Blah extends the TXTOS stack
+
+**Track**  
+Internal milestone
+
+**What became public**  
+[TXT: Blah Blah Blah](https://github.com/onestardao/WFGY/blob/main/OS/BlahBlahBlah/README.md) appeared as an embedding and semantics-related submodule integrated with TXTOS.
+
+**Why this matters**  
+This is one of the earlier signs that WFGY was growing as a family of connected modules rather than a single page or one-off idea.
+
+---
+
+## 2025/07/28 · 🗺️ Problem Map 1.0 becomes the practical wedge
+
+**Track**  
+Internal milestone
+
+**What became public**  
+[Problem Map 1.0](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md) published the original 16-mode diagnostic map for failure modes and fixes.
+
+**Why this matters**  
+This is one of the most important turning points in the whole timeline.  
+It gave WFGY a practical front door that real RAG and agent teams could understand quickly.
+
+---
+
+## 2025/07/28 · 🩺 Semantic Clinic expands the teaching layer
+
+**Track**  
+Internal milestone
+
+**What became public**  
+[Semantic Clinic](https://github.com/onestardao/WFGY/blob/main/ProblemMap/SemanticClinicIndex.md) added a structured teaching surface for injection, memory bugs, drift patterns, triage, and treatment.
+
+**Why this matters**  
+It showed that WFGY was not only classifying failures, but also teaching people how to reason about them.
+
+---
+
+## 2025/07/30 · 🧠 Semantic Blueprint deepens the theory layer
+
+**Track**  
+Internal milestone
+
+**What became public**  
+[Semantic Blueprint](https://github.com/onestardao/WFGY/blob/main/SemanticBlueprint/README.md) introduced a layer-based symbolic reasoning blueprint and semantic modulation notes.
+
+**Why this matters**  
+This strengthened the internal architecture story behind the public-facing maps and teaching pages.
+
+---
+
+## 2025/09/05 · 🛠️ Global Fix Map extends beyond one checklist
+
+**Track**  
+Internal milestone
+
+**What became public**  
+[Global Fix Map](https://github.com/onestardao/WFGY/blob/main/ProblemMap/GlobalFixMap/README.md) expanded the system into cross-tool guardrails and fix patterns for VectorDBs, agents, embeddings, dev tools, and more.
+
+**Why this matters**  
+This is where the scope clearly widened from a single 16-problem entry map into a broader systems-facing fix library.
+
+---
+
+## 2025/09/14 · 👵 Grandma Clinic turns the map into memory-friendly teaching
+
+**Track**  
+Internal milestone
+
+**What became public**  
+[Your Grandma Knows the 16 AI Bugs](https://github.com/onestardao/WFGY/tree/main/ProblemMap/GrandmaClinic) translated the 16 failure modes into everyday analogies and teaching-friendly narratives.
+
+**Why this matters**  
+This made the WFGY diagnostic layer more memorable and easier to teach beyond narrowly technical audiences.
+
+---
+
+## 2026/01/31 · 🌌 WFGY 3.0 Singularity Demo opens the frontier evaluation layer
+
+**Track**  
+Internal milestone
+
+**What became public**  
+[WFGY 3.0 · Singularity Demo](https://github.com/onestardao/WFGY/blob/main/TensionUniverse/WFGY-3.0_Singularity-Demo_AutoBoot_SHA256-Verifiable.txt) introduced a reproducible TXT-based entry point for self-evaluation, stress testing, and long-horizon reasoning exploration.
+
+**Why this matters**  
+This is a major expansion of the WFGY line.  
+It pushed the project from diagnostic and teaching surfaces into a more ambitious evaluation and reasoning arena.
+
+---
+
+## 2026/02/17 · 🌍 ToolUniverse shows tool-level public integration
+
+**Track**  
+Public ecosystem milestone
+
+**What became public**  
+ToolUniverse publicly merged a WFGY-related triage surface through [PR #75](https://github.com/mims-harvard/ToolUniverse/pull/75).
+
+**Why this matters**  
+This is stronger than a loose mention.  
+It suggests that WFGY could be wrapped into an actionable tool pathway, not only cited as an idea.
+
+---
+
+## 2026/02/20 · 📚 Rankify and Multimodal RAG Survey widen the external signal
+
+**Track**  
+Public ecosystem milestone
+
+**What became public**  
+[Rankify PR #76](https://github.com/DataScienceUIBK/Rankify/pull/76) added WFGY-style structured troubleshooting into docs.  
+[Multimodal RAG Survey PR #4](https://github.com/llm-lab-org/Multimodal-RAG-Survey/pull/4) added WFGY as a robustness-oriented resource.
+
+**Why this matters**  
+This date matters because the signal diversified.  
+WFGY was no longer visible in only one style of external context.  
+It was starting to appear across both practical docs and research-facing material.
+
+---
+
+## 2026/02/23 · 🚪 LlamaIndex makes the wedge more mainstream
+
+**Track**  
+Public ecosystem milestone
+
+**What became public**  
+[LlamaIndex PR #20760](https://github.com/run-llama/llama_index/pull/20760) merged a WFGY-style advanced failure checklist into docs.
+
+**Why this matters**  
+This is one of the clearest mainstream ecosystem signals in the timeline.  
+It shows that structured WFGY-style failure mapping is legible inside a major public RAG stack.
+
+---
+
+## 2026/02/25 · 🧯 RAGFlow strengthens the operational debugging signal
+
+**Track**  
+Public ecosystem milestone
+
+**What became public**  
+[RAGFlow PR #13204](https://github.com/infiniflow/ragflow/pull/13204) merged a structured RAG failure modes guide adapted from the WFGY Problem Map line.
+
+**Why this matters**  
+This strongly reinforces the practical wedge of WFGY.  
+It shows the map is useful in operational debugging contexts, not only in teaching or theory.
+
+---
+
+## 2026/03/01 · 🔍 FlashRAG reinforces cross-stack reuse
+
+**Track**  
+Public ecosystem milestone
+
+**What became public**  
+[FlashRAG PR #224](https://github.com/RUC-NLPIR/FlashRAG/pull/224) merged a public debug checklist and failure-mode-oriented surface.
+
+**Why this matters**  
+By this point, the pattern is harder to dismiss as an isolated one-off.  
+The same wedge is being adapted across multiple public stacks.
+
+---
+
+## 2026/03/03 · 🖼️ Problem Map 2.0 Global Debug Card turns the map into image protocol
+
+**Track**  
+Internal milestone
+
+**What became public**  
+[Problem Map 2.0 Global Debug Card](https://github.com/onestardao/WFGY/releases/tag/WFGY-Global-Debug-Card) was released as an image-first diagnostic protocol for RAG runs.
+
+**Why this matters**  
+This is a major packaging milestone.  
+It compressed the WFGY diagnostic line into a faster, more shareable, more reusable format across platforms and models.
+
+---
+
+## 2026/03/04 · 🤖 LightAgent extends the signal into multi-agent territory
+
+**Track**  
+Public ecosystem milestone
+
+**What became public**  
+[LightAgent PR #24](https://github.com/wanxingai/LightAgent/pull/24) merged a multi-agent failure map entry with WFGY-related linkage.
+
+**Why this matters**  
+This matters because it widened the visible wedge beyond classic RAG debugging and into multi-agent coordination and failure diagnosis.
+
+---
+
+## 2026/03/08 · 🧭 Public proof becomes a first-class routing layer in WFGY
+
+**Track**  
+Packaging milestone
+
+**What became public**  
+The main [WFGY homepage](https://github.com/onestardao/WFGY/blob/main/README.md) now routes users through a distinct public-proof layer:
+
+* [ADOPTERS](./ADOPTERS.md)
+* [CASE_EVIDENCE](./CASE_EVIDENCE.md)
+* [Recognition Map](./recognition/README.md)
+
+It also exposes a dedicated collaboration entry through [Work with WFGY](./WORK_WITH_WFGY.md).
+
+**Why this matters**  
+This does not create new third-party proof by itself.  
+What it does is make the accumulated evidence auditable, legible, and much easier to evaluate in one pass.
+
+---
+
+# What this timeline currently shows
+
+📌 At the current stage, the historical pattern is fairly clear.
+
+WFGY did not appear all at once as one finished artifact.  
+It grew in layers.
+
+The rough sequence looks like this:
+
+1. **baseline and theory**
+2. **application surfaces**
+3. **diagnostic maps**
+4. **teaching and fix systems**
+5. **frontier evaluation**
+6. **external ecosystem proof**
+7. **public packaging and collaboration routing**
+
+That matters because it shows continuity.
+
+The strongest external wedge today still appears to be the **Problem Map line**, especially the structured debugging and failure-classification layer.  
+That is the part that became easiest for outside projects to understand, adapt, and reuse.
+
+At the same time, the internal timeline shows that WFGY is broader than that wedge alone.  
+The project has also been building theory surfaces, application surfaces, and frontier evaluation surfaces in parallel.
+
+## Safest reading
+
+The safest disciplined reading today is:
+
+* WFGY has a real historical build-up, not a sudden one-page appearance
+* the system became practical through the Problem Map line
+* the strongest public adoption signal still clusters around diagnostic and debugging use
+* the broader WFGY stack is larger than that single wedge, but public proof is currently strongest there
+* the timeline shows continuity, structure, and increasing external legibility, but should not be exaggerated into universal adoption claims
+
+---
+
+# Maintenance rules
+
+🧾 When updating this page:
+
+1. Keep the timeline chronological.
+2. Prefer dates when something became publicly visible in stable form.
+3. Separate internal milestones from external proof in wording, even if they share the same page.
+4. Do not retroactively inflate old events into stronger claims.
+5. If a milestone is important but weak, move it to the [Recognition Map](./recognition/README.md) instead.
+6. If an event belongs mainly to explanation rather than chronology, keep it in [CASE_EVIDENCE](./CASE_EVIDENCE.md).
+
+---
+
+# Related pages
+
+* [ADOPTERS](./ADOPTERS.md)
+* [CASE_EVIDENCE](./CASE_EVIDENCE.md)
+* [Recognition Map](./recognition/README.md)
+* [Work with WFGY](./WORK_WITH_WFGY.md)
+* [Problem Map 1.0](./ProblemMap/README.md)
+* [Problem Map 2.0 Global Debug Card](https://github.com/onestardao/WFGY/releases/tag/WFGY-Global-Debug-Card)
+
+---
+
+Last updated: 2026/03/08  
+Maintained manually.


### PR DESCRIPTION
This PR introduces a new document: `EVIDENCE_TIMELINE.md`.

The page records the historical development path of WFGY, including:

- internal framework milestones
- teaching and documentation releases
- ecosystem-related moments where the work became more public or reproducible

The goal is to provide a chronological reference for readers who want to understand how the WFGY framework evolved over time.

No functional changes — documentation only.