### PR TITLE
docs: clarify Global Debug Card FAQ

### DIFF
--- a/ProblemMap/wfgy-rag-16-problem-map-global-debug-card.md
+++ b/ProblemMap/wfgy-rag-16-problem-map-global-debug-card.md
@@ -698,6 +698,20 @@ Later waves are expected to:
 ## FAQ
 
 <details>
+<summary><b>What is the purpose of the Global Debug Card?</b></summary>
+
+<br>
+
+The Global Debug Card is a compact first-pass diagnostic tool for failing RAG and agent pipelines.
+It helps map a concrete failure to likely problem modes, identify where the pipeline is drifting, and pair each proposed fix with a verification test.
+
+It is a triage aid, not proof of a root cause or a replacement for logs, evaluation, and system-specific investigation.
+
+</details>
+
+---
+
+<details>
 <summary><b>Do I need all four objects `(Q, E, P, A)` to use the Global Debug Card?</b></summary>
 
 <br>
@@ -718,6 +732,20 @@ If one object is missing, the card can still be used for partial triage:
 - missing both `E` and `P` reduces accuracy, but the card can still help identify likely failure families
 
 In short: all four objects are ideal, but partial inputs can still be useful for first-pass diagnosis.
+
+</details>
+
+---
+
+<details>
+<summary><b>Does using the Global Debug Card require infrastructure changes?</b></summary>
+
+<br>
+
+No infrastructure change is required for first-pass use.
+You can upload the card to a capable LLM and provide the available parts of `(Q, E, P, A)` along with any useful logs or metrics.
+
+Automation, structured debug packets, or additional observability can improve repeatability later, but they are optional extensions rather than prerequisites.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds two concise FAQ entries to the Global Debug Card page. The new entries explain the card’s purpose and clarify that first-pass use does not require infrastructure changes. This helps first-time readers understand the card’s role, limitations, and basic usage requirements.

---

## What this PR changes

- [x] Documentation wording or structure
- [ ] Navigation or routing improvement
- [ ] Recognition or public proof update
- [ ] Adopters / Case Evidence / Evidence Timeline update
- [ ] Collaboration or pilot-related page
- [ ] Template or contribution workflow
- [ ] Metadata or repository structure
- [ ] Bug fix
- [ ] Other

---

## Affected surfaces

- `ProblemMap/wfgy-rag-16-problem-map-global-debug-card.md`

---

## Why this matters

The additional FAQ entries reduce confusion for first-time readers by explaining what the Global Debug Card is designed to do and what it does not replace. They also clarify that readers can begin using the card without changing their infrastructure, while noting that observability and automation can improve repeatability later.

---

## Linked issue

Closes #79

---

## Public proof or evidence

Not applicable. This PR does not add or modify public proof.

---

## Screenshots or render checks

The two entries follow the page’s existing collapsible `<details>` FAQ structure. The opening and closing `<details>` tags were checked and remain balanced.

---

## Non-claims and boundaries

This is a documentation clarification, not a change to the Global Debug Card protocol. It does not claim that the card proves a root cause, guarantees a repair, or replaces logs, evaluation, and system-specific investigation.

---

## Checklist

- [x] I reviewed the changed text for clarity and consistency
- [x] I checked links, filenames, and page references
- [x] I kept claims conservative and evidence-based
- [x] If this PR adds public proof, I included a stable public source — Not applicable
- [x] If this PR affects routing, I checked whether the destination pages are correct — Not applicable
- [x] I avoided overstating adoption, deployment, or collaboration status
- [x] I updated related pages when necessary, or intentionally left them unchanged